### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,9 @@
 import sys, os, re
 from typing import Any, Dict, List, Optional, Callable
 
+# Define the safe base directory for importable resources
+BASE_DATA_DIR = os.path.abspath(os.path.dirname(__file__))
+
 # ---- Tool Implementations (Stubs) ----
 from tools.core_logic import *
 from tools.api_stubs import *
@@ -132,7 +135,9 @@ class Agent:
 # ---- Loader ----
 def resolve_path(base_file: str, rel: str) -> str:
     base_dir = os.path.dirname(base_file)
-    abs_path = os.path.normpath(os.path.join(base_dir, rel))
+    abs_path = os.path.abspath(os.path.normpath(os.path.join(base_dir, rel)))
+    if not abs_path.startswith(BASE_DATA_DIR + os.sep):
+        raise Exception(f"Access to path '{abs_path}' is not allowed. It must reside within '{BASE_DATA_DIR}'.")
     if not os.path.exists(abs_path):
         raise FileNotFoundError(f"Missing import: {rel} -> {abs_path}")
     return abs_path


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/chatgpts-actions/security/code-scanning/3](https://github.com/billlzzz10/chatgpts-actions/security/code-scanning/3)

To fix this issue, we need to ensure the paths constructed by `resolve_path` do not escape a defined safe root directory (for instance, the root directory containing all approved YAML or prompt/rule/tool files). This can be achieved by defining a root path (such as the project directory), and then, after joining and normalizing the resulting path, verifying that the final path still starts with the root. This prevents directory traversal or absolute path values from being used to reference files outside the allowed area.

**Steps:**
- Define a root directory (e.g., `BASE_DATA_DIR`), ideally as an absolute path.
- In `resolve_path`, after normalizing, check that the resulting absolute path starts with `BASE_DATA_DIR`. If not, raise an exception.
- Add the definition of `BASE_DATA_DIR` early in the file. For a simple, robust fix, use the directory containing `app.py` as the base (or whatever is most appropriate for your app's runtime).

**Required imports:** None, as `os` is already imported.

**Required changes:**
- Insert `BASE_DATA_DIR` definition near the top.
- Modify `resolve_path` to check that `abs_path` is within `BASE_DATA_DIR`.
- Raise an exception if not.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
